### PR TITLE
Add navigation and updated landing page

### DIFF
--- a/src/components/NavHeader.astro
+++ b/src/components/NavHeader.astro
@@ -1,0 +1,46 @@
+---
+---
+<header class="site-header">
+  <nav class="container">
+    <a href="/" class="logo">Dojo du Management</a>
+    <ul class="nav-links">
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/articles/">Articles</a></li>
+    </ul>
+  </nav>
+  <style>
+    .site-header {
+      background: var(--bg);
+      border-bottom: 2px solid var(--accent);
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 0.5rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .logo {
+      font-family: 'Sawarabi Mincho', serif;
+      font-size: 1.4rem;
+      color: var(--indigo);
+      text-decoration: none;
+    }
+    .nav-links {
+      list-style: none;
+      display: flex;
+      gap: 1rem;
+      margin: 0;
+      padding: 0;
+    }
+    .nav-links a {
+      text-decoration: none;
+      color: var(--ink);
+      font-weight: bold;
+    }
+    .nav-links a:hover {
+      color: var(--accent);
+    }
+  </style>
+</header>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,24 +1,33 @@
+---
+export interface Props {
+  title?: string;
+}
+const { title = 'Dojo du Management' } = Astro.props;
+import NavHeader from '../components/NavHeader.astro';
+---
+
 <!doctype html>
-<html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&family=Sawarabi+Mincho&display=swap" rel="stylesheet">
-		<link rel="stylesheet" href="/src/styles/global.css">
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro Basics</title>
-	</head>
-	<body>
-		<slot />
-	</body>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;700&family=Sawarabi+Mincho&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/src/styles/global.css" />
+    <meta name="generator" content={Astro.generator} />
+    <title>{title}</title>
+  </head>
+  <body>
+    <NavHeader />
+    <slot />
+  </body>
 </html>
 
 <style>
-	html,
-	body {
-		margin: 0;
-		width: 100%;
-		height: 100%;
-	}
+  html,
+  body {
+    margin: 0;
+    width: 100%;
+    height: 100%;
+  }
 </style>

--- a/src/layouts/MarkdownLayout.astro
+++ b/src/layouts/MarkdownLayout.astro
@@ -7,6 +7,7 @@ export interface Props {
 }
 
 const { title, pubDate, author, description } = Astro.props;
+import NavHeader from '../components/NavHeader.astro';
 ---
 
 <html lang="fr">
@@ -14,7 +15,8 @@ const { title, pubDate, author, description } = Astro.props;
     <meta charset="UTF-8" />
     <title>{title}</title>
     <meta name="description" content={description || ''} />
-    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+JP&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/src/styles/global.css" />
     <style>
       body {
         margin: 0;
@@ -64,6 +66,7 @@ const { title, pubDate, author, description } = Astro.props;
     </style>
   </head>
   <body>
+    <NavHeader />
     <article>
       <h1>{title}</h1>
       <p class="meta">

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -1,0 +1,35 @@
+---
+import Layout from '../../layouts/Layout.astro'
+import { getCollection } from 'astro:content'
+import ArticleCard from '../../components/ArticleCard.astro'
+
+const articles = await getCollection('articles')
+---
+
+<Layout title="Articles">
+  <main class="liste-articles">
+    <h1>Tous les articles</h1>
+    {articles.map(({ data, slug }) => (
+      <ArticleCard
+        title={data.title}
+        description={data.description}
+        pubDate={data.pubDate}
+        href={`/articles/${slug}/`}
+      />
+    ))}
+  </main>
+
+  <style>
+    .liste-articles {
+      max-width: 700px;
+      margin: auto;
+      padding: 3rem 1rem;
+      font-family: 'Noto Serif JP', serif;
+    }
+    h1 {
+      font-size: 1.8rem;
+      margin-bottom: 2rem;
+      color: var(--indigo);
+    }
+  </style>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,11 @@ const derniersArticles = articles.slice(0, 3)
 
 <Layout title="Dojo du Management">
   <main class="accueil">
+    <section class="hero">
+      <h1>Dojo du Management</h1>
+      <p>Explorez l'art de diriger avec clarté et sérénité.</p>
+      <p><a href="/articles/" class="cta">Voir tous les articles</a></p>
+    </section>
 
     <section class="citation">
       <blockquote>
@@ -48,6 +53,29 @@ const derniersArticles = articles.slice(0, 3)
       margin: auto;
       padding: 3rem 1rem;
       font-family: 'Noto Serif JP', serif;
+    }
+
+    .hero {
+      text-align: center;
+      margin-bottom: 3rem;
+    }
+    .hero h1 {
+      font-size: 2.2rem;
+      margin: 0;
+      color: var(--indigo);
+      font-family: 'Sawarabi Mincho', serif;
+    }
+    .hero .cta {
+      display: inline-block;
+      margin-top: 1rem;
+      padding: 0.5rem 1rem;
+      background: var(--indigo);
+      color: white;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    .hero .cta:hover {
+      background: var(--accent);
     }
 
     .citation blockquote {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,32 +1,31 @@
 :root {
-    --bg: #faf8f5;
-    --text: #1e1e1e;
-    --accent: #5e4b56;  /* bordeaux foncé */
-    --ink: #2c2c2c;     /* encre de chine */
-    --indigo: #4b6e91;
-  }
-  
-  body {
-    background-image: url('/bg-washi.jpg');
-    background-size: cover;
-    background-repeat: repeat;
-    background-attachment: fixed;
-    opacity: 0.98;
-    font-family: 'Noto Serif JP', serif;
-  }
-  
-  body::before {
-    content: '';
-    position: fixed;
-    top: 0; left: 0;
-    width: 100%; height: 100%;
-    background-image: url('/bg-washi.jpg');
-    background-size: cover;
-    background-repeat: repeat;
-    background-attachment: fixed;
-    opacity: 0.05;
-    z-index: -1;
-  }
-    
-  
-  
+  --bg: #faf8f5;
+  --text: #1e1e1e;
+  --accent: #5e4b56;  /* bordeaux foncé */
+  --ink: #2c2c2c;     /* encre de chine */
+  --indigo: #4b6e91;
+}
+
+body {
+  background-image: url('/bg-washi.jpg');
+  background-size: cover;
+  background-repeat: repeat;
+  background-attachment: fixed;
+  opacity: 0.98;
+  font-family: 'Noto Serif JP', serif;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url('/bg-washi.jpg');
+  background-size: cover;
+  background-repeat: repeat;
+  background-attachment: fixed;
+  opacity: 0.05;
+  z-index: -1;
+}


### PR DESCRIPTION
## Summary
- make a navigation header component
- use the header in both layouts
- create a page listing all articles
- refresh the homepage with a hero section
- clean global styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68464e2f0600832594d1111fc6d37fcd